### PR TITLE
Add support for FUNDING.yml in community health file

### DIFF
--- a/Sources/Spasibo/Spasibo.swift
+++ b/Sources/Spasibo/Spasibo.swift
@@ -29,11 +29,11 @@ struct Spasibo: ParsableCommand {
             dependencies.append(contentsOf: packageDependencies)
         }
 
-        try addFundings(to: dependencies)
-
         if dependencies.isEmpty {
             throw Error.noDependencies
         }
+
+        try addFundings(to: dependencies)
 
         let fundingDependencies = dependencies.filter { dependency in
             dependency.fundings.isEmpty == false

--- a/Sources/Spasibo/Spasibo.swift
+++ b/Sources/Spasibo/Spasibo.swift
@@ -108,16 +108,38 @@ struct Spasibo: ParsableCommand {
 
     private func addFundings(to dependencies: [Dependency]) throws {
         for dependency in dependencies {
-            guard let fundingURL = URL.funding(owner: dependency.owner, name: dependency.name) else {
-                continue
-            }
-            let content = try String(contentsOf: fundingURL)
-            guard let rawFundings = try Yams.load(yaml: content) as? [String: Any] else {
-                continue
-            }
-            dependency.fundings = rawFundings.compactMap { key, value in
-                Funding(key: key, value: value)
-            }
+            try addFunding(to: dependency)
+        }
+    }
+
+    private func addFunding(to dependency: Dependency) throws {
+        try addDirectFunding(to: dependency)
+        if dependency.fundings.isEmpty {
+            try addHealthFunding(to: dependency)
+        }
+    }
+
+    private func addDirectFunding(to dependency: Dependency) throws {
+        guard let fundingURL = URL.funding(owner: dependency.owner, name: dependency.name) else {
+            return
+        }
+        dependency.fundings = try fetchFundings(from: fundingURL)
+    }
+
+    private func addHealthFunding(to dependency: Dependency) throws {
+        guard let fundingURL = URL.healthFunding(owner: dependency.owner) else {
+            return
+        }
+        dependency.fundings = try fetchFundings(from: fundingURL)
+    }
+
+    private func fetchFundings(from url: URL) throws -> [Funding] {
+        let content = try String(contentsOf: url)
+        guard let rawFundings = try Yams.load(yaml: content) as? [String: Any] else {
+            return []
+        }
+        return rawFundings.compactMap { key, value in
+            Funding(key: key, value: value)
         }
     }
 }

--- a/Sources/Spasibo/URL+Additions.swift
+++ b/Sources/Spasibo/URL+Additions.swift
@@ -13,4 +13,12 @@ extension URL {
         components.path = "/\(owner)/\(name)/master/.github/FUNDING.yml"
         return components.url
     }
+
+    static func healthFunding(owner: String) -> URL? {
+        var components = URLComponents()
+        components.scheme = "https"
+        components.host = "raw.githubusercontent.com"
+        components.path = "/\(owner)/.github/master/FUNDING.yml"
+        return components.url
+    }
 }


### PR DESCRIPTION
Hi @artemnovichkov, thank you for building this tool! 🙌 

This PR adds support for `.FUNDING.yml` declared in a user [Community Health files](https://help.github.com/en/github/building-a-strong-community/creating-a-default-community-health-file). 

For example, in [none](https://github.com/zntfdr/Selenops) [of](https://github.com/zntfdr/Connection) [my](https://github.com/zntfdr/AStack) [packages](https://github.com/zntfdr/Sight) there is a `.github/FUNDING.yml` file, however GitHub still displays the Funding badge because it picks up my [`.FUNDING.yml` file](https://raw.githubusercontent.com/zntfdr/.github/master/FUNDING.yml) from my health files, a.k.a [my `.github` repository](https://github.com/zntfdr/.github/).

In order to support this feature:
- a new URL static `healthFunding` method has been created.
- a `addFundings` refactoring has been done.

